### PR TITLE
feat: calculate optimal specific humidity

### DIFF
--- a/.devcontainer/configuration.yaml
+++ b/.devcontainer/configuration.yaml
@@ -21,14 +21,15 @@ input_number:
     name: Indoor Humidity
     min: 0
     max: 100
-    initial: 40
+    initial: 45
+    step: .5
     mode: slider
     unit_of_measurement: "%"
   indoor_temp_sensor:
     name: Indoor Temperature
     min: 0
     max: 100
-    initial: 24.5
+    initial: 21
     step: .5
     mode: slider
     unit_of_measurement: °C
@@ -44,7 +45,7 @@ input_number:
     name: Pressure Sensor
     min: 0
     max: 108480
-    initial: 89500
+    initial: 101325
     unit_of_measurement: Pa
 
 sensor:

--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ sensor:
 
 |Parameter |Required|Description
 |:---|---|---
-| `name` | No | Friendly name **Default**: Optimal Humidity
-| `type` | No | The type of sensor to use for the primary state.  One of `optimal_humidity`, `specific_humidity`, `dewpoint`, `critical_humidity`, `mold_warning`, `humidex`, or `humidex_comfort` **Default**: `optimal_humidity`
 | `indoor_temp_sensor` | Yes | Temperature sensor to use for calculations. Typically the warmest sensor in the room.
-| `critical_temp_sensor` | Yes | Temperature sensor to use for calculations to avoid mold and condensation. Typically the coldest sensor in the room.
-| `indoor_pressure_sensor` | No | Pressue sensor to use for calculations.  If not included, will use the elevation set in Home Assistant to calculate the Standard Air Pressure.
 | `indoor_humidity_sensor` | Yes | Humidity sensor to use for calculations. Typically in the same location as the `indoor_temp_sensor`.
-| `optimal_specific_humidity` | No | Optimal specific humidity in grams of H₂O per gram of Air⁻¹ **Default**: 7
+| `critical_temp_sensor` | Yes | Temperature sensor to use for calculations to avoid mold and condensation. Typically the coldest sensor in the room.
+| `name` | No | Friendly name **Default**: Optimal Humidity
+| `type` | No | The type of sensor to use for the primary state.  Value can be any of the attributes listed below. **Default**: `optimal_humidity`
+| `indoor_pressure_sensor` | No | Pressue sensor to use for calculations.  If not included, will use the elevation set in Home Assistant to calculate the Standard Air Pressure.
+| `optimal_specific_humidity` | No | Overrides the optimal specific humidity calculation.  In grams of H₂O per gram of Air⁻¹ **Default**: Calculated based on `indoor_pressure_sensor` if available, or from Home Assistants elevation setting if not.
 
 ### Attributes
 
@@ -79,6 +79,7 @@ sensor:
 |:---|---|---
 | `dewpoint` | °C/°F | Dewpoint from the `indoor_temp_sensor` and `indoor_humidity_sensor` and `indoor_pressure_sensor` combined.
 | `optimal_humidity` | % | The optimal set point in relative humidity for a humidifier or dehumidifier.
+| `optimal_specific_humidity` | grams of H₂O per gram of Air⁻¹ | Calculated based on `indoor_pressure_sensor` or Home Assitants elevation setting.  Can be overriden by using the `optimal_specific_humidity` option.
 | `specific_humidity` | grams of H₂O per gram of Air⁻¹ | Specific humidity from the `indoor_temp_sensor` and `indoor_humidity_sensor` and `indoor_pressure_sensor` combined.
 | `critical_humidity` | % | Calculated critical humidity at the coldest point in the room, using the `critical_temp_sensor`.
 | `mold_warningr` | boolean | Whether or not there is a risk of mold at either the critical point or the indoor sensor location.

--- a/custom_components/optimal_humidity/const.py
+++ b/custom_components/optimal_humidity/const.py
@@ -29,8 +29,9 @@ CONF_INDOOR_HUMIDITY = "indoor_humidity_sensor"
 CONF_INDOOR_TEMP = "indoor_temp_sensor"
 CONF_INDOOR_PRESSURE = "indoor_pressure_sensor"
 CONF_OPTIMAL_SPECIFIC_HUMIDITY = "optimal_specific_humidity"
-# 7g/m³ seems to be a comfortable default
-DEFAULT_OPTIMAL_SPECIFIC_HUMIDITY = 7
+# 7.8g_H₂O g_Air⁻¹ seems to be a comfortable default based on 45% RH
+# and 21°C being the ideal conditions for humans
+DEFAULT_OPTIMAL_SPECIFIC_HUMIDITY = 7.8
 
 DEFAULT_NAME = "Optimal Humidity"
 

--- a/custom_components/optimal_humidity/const.py
+++ b/custom_components/optimal_humidity/const.py
@@ -19,6 +19,7 @@ ISSUE_URL = "https://github.com/TheRealWaldo/ha-optimal-humidity/issues"
 ATTR_DEWPOINT = "dewpoint"
 ATTR_SPECIFIC_HUMIDITY = "specific_humidity"
 ATTR_OPTIMAL_HUMIDITY = "optimal_humidity"
+ATTR_OPTIMAL_SPECIFIC_HUMIDITY = "optimal_specific_humidity"
 ATTR_CRITICAL_HUMIDITY = "critical_humidity"
 ATTR_MOLD_WARNING = "mold_warning"
 ATTR_HUMIDEX = "humidex"
@@ -29,12 +30,13 @@ CONF_INDOOR_HUMIDITY = "indoor_humidity_sensor"
 CONF_INDOOR_TEMP = "indoor_temp_sensor"
 CONF_INDOOR_PRESSURE = "indoor_pressure_sensor"
 CONF_OPTIMAL_SPECIFIC_HUMIDITY = "optimal_specific_humidity"
-# 7.8g_H₂O g_Air⁻¹ seems to be a comfortable default based on 45% RH
-# and 21°C being the ideal conditions for humans
-DEFAULT_OPTIMAL_SPECIFIC_HUMIDITY = 7.8
+
+IDEAL_HUMIDITY = 0.45
+IDEAL_TEMPERATURE = 21
 
 DEFAULT_NAME = "Optimal Humidity"
 
+GRAMS_OF_WATER_TO_GRAMS_OF_AIR = "g_H₂O g_Air⁻¹"
 SENSOR_TYPES = {
     ATTR_DEWPOINT: (
         ATTR_DEWPOINT,
@@ -44,7 +46,7 @@ SENSOR_TYPES = {
     ),
     ATTR_SPECIFIC_HUMIDITY: (
         ATTR_SPECIFIC_HUMIDITY,
-        "g_H₂O g_Air⁻¹",
+        GRAMS_OF_WATER_TO_GRAMS_OF_AIR,
         "",
         "mdi:water",
     ),
@@ -71,6 +73,12 @@ SENSOR_TYPES = {
         None,
         None,
         "hass:account",
+    ),
+    ATTR_OPTIMAL_SPECIFIC_HUMIDITY: (
+        ATTR_OPTIMAL_SPECIFIC_HUMIDITY,
+        GRAMS_OF_WATER_TO_GRAMS_OF_AIR,
+        "",
+        "mdi:water",
     ),
 }
 


### PR DESCRIPTION
It was discovered through testing that air pressure significantly
impacts specific humidity when calculated from relative humidity and
temperature.

So rather than having a fixed default for the optimal specific humidity,
we calculate it based on air pressure.